### PR TITLE
Add a fix for Safari to the default config

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,9 @@ module.exports = {
           // limit sequences because of memory issues during parsing
           sequences: 30,
         },
+        mangle: {
+          safari10: true
+        },
         output: {
           // no difference in size and much easier to debug
           semicolons: false,


### PR DESCRIPTION
Uglifying ES6 doesn't work currently with Safari due to a webkit bug.
Adding this mangle option fixes that.

Fixes #25