### PR TITLE
Updates broccoli-uglify-sourcemap to version 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v2.0.1 (2018-01-22)
+
+#### :rocket: Enhancement
+* [#29](https://github.com/ember-cli/ember-cli-uglify/pull/29) Update "broccoli-uglify-sourcemap" to v2.0.1. ([@Duder-onomy](https://github.com/Duder-onomy))
+
+#### Committers: 1
+- Greg Larrenaga ([Duder-onomy](https://github.com/duder-onomy))
+
 ## v2.0.0 (2017-10-03)
 
 #### :rocket: Enhancement

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-uglify",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "JavaScript minification for Ember-CLI",
   "keywords": [
     "ember-addon"
@@ -21,7 +21,7 @@
     "test": "ember test"
   },
   "dependencies": {
-    "broccoli-uglify-sourcemap": "^2.0.0",
+    "broccoli-uglify-sourcemap": "^2.0.1",
     "lodash.defaultsdeep": "^4.6.0"
   },
   "engines": {


### PR DESCRIPTION
I was having some issues similar to this issue: https://github.com/ember-cli/broccoli-uglify-sourcemap/issues/53

I check and this merged and versioned PR fixes things for me: https://github.com/ember-cli/broccoli-uglify-sourcemap/blob/master/CHANGELOG.md#v201-2017-11-16

Please let me know if there is anything I can do to push this along. 
Rawk!