### PR TITLE
Run uglify in parallel

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ module.exports = {
 
     let defaultOptions = {
       enabled: app.env === 'production',
+      async: true, // run uglify in parallel
 
       uglify: {
         compress: {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:all": "ember try:each -- ember test -e production"
   },
   "dependencies": {
-    "broccoli-uglify-sourcemap": "^2.0.1",
+    "broccoli-uglify-sourcemap": "^2.1.1",
     "lodash.defaultsdeep": "^4.6.0"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -219,7 +219,7 @@ async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
 
-async-promise-queue@^1.0.3:
+async-promise-queue@^1.0.3, async-promise-queue@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/async-promise-queue/-/async-promise-queue-1.0.4.tgz#308baafbc74aff66a0bb6e7f4a18d4fe8434440c"
   dependencies:
@@ -1112,10 +1112,11 @@ broccoli-stew@^1.2.0, broccoli-stew@^1.3.3:
     symlink-or-copy "^1.1.8"
     walk-sync "^0.3.0"
 
-broccoli-uglify-sourcemap@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/broccoli-uglify-sourcemap/-/broccoli-uglify-sourcemap-2.0.2.tgz#f4a73112f1f56b46043e2e89cba5ce7762cddeb3"
+broccoli-uglify-sourcemap@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/broccoli-uglify-sourcemap/-/broccoli-uglify-sourcemap-2.1.1.tgz#33005537e18a322a181a5aea3e46d145b3355630"
   dependencies:
+    async-promise-queue "^1.0.4"
     broccoli-plugin "^1.2.1"
     debug "^3.1.0"
     lodash.defaultsdeep "^4.6.0"
@@ -1125,6 +1126,7 @@ broccoli-uglify-sourcemap@^2.0.1:
     symlink-or-copy "^1.0.1"
     uglify-es "^3.1.3"
     walk-sync "^0.3.2"
+    workerpool "^2.3.0"
 
 browserslist@^2.1.2:
   version "2.11.3"
@@ -1794,9 +1796,9 @@ ember-cli-test-loader@^2.2.0:
     ember-cli-babel "^6.8.1"
 
 ember-cli-uglfiy@./:
-  version "2.0.1"
+  version "2.0.2"
   dependencies:
-    broccoli-uglify-sourcemap "^2.0.1"
+    broccoli-uglify-sourcemap "^2.1.1"
     lodash.defaultsdeep "^4.6.0"
 
 ember-cli-valid-component-name@^1.0.0:


### PR DESCRIPTION
Use recent enhancements from https://github.com/ember-cli/broccoli-uglify-sourcemap/pull/63 to run uglify in parallel using worker processes to provide a production build speedup.