### PR TITLE
Drop support for Node.js 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "4"
+  - "6"
 
 sudo: false
 dist: trusty

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,6 @@
 environment:
   MOCHA_REPORTER: "mocha-appveyor-reporter"
   matrix:
-    - nodejs_version: "4"
     - nodejs_version: "6"
     - nodejs_version: "8"
     - nodejs_version: "9"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,6 @@ environment:
   MOCHA_REPORTER: "mocha-appveyor-reporter"
   matrix:
     - nodejs_version: "6"
-    - nodejs_version: "8"
-    - nodejs_version: "9"
 
 branches:
   only:

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lodash.defaultsdeep": "^4.6.0"
   },
   "engines": {
-    "node": "^4.5 || 6.* || >= 7.*"
+    "node": "6.* || 8.* || >= 10.*"
   },
   "changelog": {
     "repo": "ember-cli/ember-cli-uglify",


### PR DESCRIPTION
This should fix CI on AppVeyor.