### PR TITLE
CI: Run only for `master` branch, tags and PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,12 @@ node_js:
 sudo: false
 dist: trusty
 
+branches:
+  only:
+    - master
+    # npm version tags
+    - /^v\d+\.\d+\.\d+/
+
 addons:
   chrome: stable
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,8 +9,6 @@ environment:
 branches:
   only:
     - master
-    - beta
-    - release
 
 # Install scripts. (runs after repo cloning)
 install:


### PR DESCRIPTION
This takes pressure from the CI system by not running twice for dependabot PRs