### PR TITLE
fix: remove unneeded and confusing dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "ember-cli-babel": "^6.11.0",
     "ember-cli-htmlbars": "^3.0.1",
     "ember-cli-qunit": "^4.4.0",
-    "ember-cli-uglfiy": "./",
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^5.0.1",
     "ember-source": "^3.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1919,12 +1919,6 @@ ember-cli-test-loader@^2.2.0:
   dependencies:
     ember-cli-babel "^6.8.1"
 
-ember-cli-uglfiy@./:
-  version "2.1.0"
-  dependencies:
-    broccoli-uglify-sourcemap "^2.2.0"
-    lodash.defaultsdeep "^4.6.0"
-
 ember-cli-valid-component-name@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-cli-valid-component-name/-/ember-cli-valid-component-name-1.0.0.tgz#71550ce387e0233065f30b30b1510aa2dfbe87ef"


### PR DESCRIPTION
Please note the typo in dependency name.

Was added in df6ab755b82bc551746041649dfce7b6eaead118.