### PR TITLE
Drop support for Node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "6"
+  - "8"
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@
 environment:
   MOCHA_REPORTER: "mocha-appveyor-reporter"
   matrix:
-    - nodejs_version: "6"
+    - nodejs_version: "8"
 
 branches:
   only:

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lodash.defaultsdeep": "^4.6.0"
   },
   "engines": {
-    "node": "6.* || 8.* || >= 10.*"
+    "node": "8.* || >= 10.*"
   },
   "changelog": {
     "repo": "ember-cli/ember-cli-uglify",


### PR DESCRIPTION
https://github.com/ember-cli/ember-cli-uglify/pull/64 was not released yet, so we may as well combine it with dropping support for Node 6, which is EOL at the end of April.