### PR TITLE
.npmignore: Ignore `yarn.lock` file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -14,6 +14,7 @@
 bower.json
 ember-cli-build.js
 testem.js
+yarn.lock
 
 # ember-try
 .node_modules.ember-try/


### PR DESCRIPTION
this is by far the largest file in the tarball that we publish...