### PR TITLE
Drop support for Node 8, 9, 11, and 13.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "8"
+  - "10"
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@
 environment:
   MOCHA_REPORTER: "mocha-appveyor-reporter"
   matrix:
-    - nodejs_version: "8"
+    - nodejs_version: "10"
 
 branches:
   only:

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lodash.defaultsdeep": "^4.6.1"
   },
   "engines": {
-    "node": "8.* || >= 10.*"
+    "node": "10.* || >= 12.*"
   },
   "changelog": {
     "repo": "ember-cli/ember-cli-uglify",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lodash.defaultsdeep": "^4.6.1"
   },
   "engines": {
-    "node": "10.* || >= 12.*"
+    "node": "10.* || 12.* || >= 14"
   },
   "changelog": {
     "repo": "ember-cli/ember-cli-uglify",


### PR DESCRIPTION
To do so, drop NodeJs v8

An example of failing CI: https://travis-ci.org/github/ember-cli/ember-cli-uglify/builds/715103846