### PR TITLE
Remove deep defaulting of minification options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ var app = new EmberApp({
 - `terser?: TerserOptions`: A hash of [options](https://github.com/terser/terser#minify-options)
   that are passed directly to terser
 
+If no `terser` option is passed, a default configuration will be used.
 
 ### Source Maps
 

--- a/index.js
+++ b/index.js
@@ -6,8 +6,6 @@ module.exports = {
   included(app) {
     this._super.included.apply(this, arguments);
 
-    const defaults = require('lodash.defaultsdeep');
-
     let defaultOptions = {
       enabled: app.env === 'production',
 
@@ -39,7 +37,7 @@ module.exports = {
       addonOptions = Object.assign({}, addonOptions, { terser: addonOptions.uglify, uglify: undefined });
     }
 
-    this._terserOptions = defaults(addonOptions, defaultOptions);
+    this._terserOptions = Object.assign({}, defaultOptions, addonOptions);
   },
 
   _sourceMapsEnabled(options) {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "test": "ember test -e production"
   },
   "dependencies": {
-    "broccoli-terser-sourcemap": "^4.1.0",
-    "lodash.defaultsdeep": "^4.6.1"
+    "broccoli-terser-sourcemap": "^4.1.0"
   },
   "engines": {
     "node": "10.* || 12.* || >= 14"


### PR DESCRIPTION
The default options will only be used now if the user does not provide a `{ 'ember-cli-uglify': { terser: { ... } }` configuration at all.