### PR TITLE
Fix upgraing from ember-cli-uglify options in ember-cli-build.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ module.exports = {
     if ('ember-cli-uglify' in app.options) {
       this.ui.writeWarnLine('[ember-cli-terser] Passing options as `ember-cli-uglify` in `ember-cli-build.js` is deprecated, please update to passing `ember-cli-terser` (with a `terser` property) instead.');
 
-      addonOptions = Object.assign({}, app.options['ember-cli-uglify'], { terser: addonOptions.uglify, uglify: undefined });
+      addonOptions = Object.assign({}, app.options['ember-cli-uglify'], { terser: app.options['ember-cli-uglify'].uglify, uglify: undefined });
     }
 
     this._terserOptions = Object.assign({}, defaultOptions, addonOptions);


### PR DESCRIPTION
We intended for this to seemlessly upgrade with a nice warning, but unfortunately there was a bug in the logic that actually made things worse (couldn't build at all).

Fixes https://github.com/ember-cli/ember-cli-terser/issues/235