### PR TITLE
Move ember-cli-terser to run after broccoli-asset-rev (reduces sourcemapping issues in some contexts)

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     }
   },
   "ember-addon": {
+    "before": "ember-cli-sri",
     "after": "broccoli-asset-rev"
   },
   "release-it": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     }
   },
   "ember-addon": {
-    "before": "broccoli-asset-rev"
+    "after": "broccoli-asset-rev"
   },
   "release-it": {
     "plugins": {


### PR DESCRIPTION
This closes #265 by implementing the suggestion mentioned in the root comment.

This also ensures that `ember-cli-sri` doesn't run before `ember-cli-terser`, since the code should be in its final state before reaching that plugin.