### PR TITLE
Revert broccoli asset rev change

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     }
   },
   "ember-addon": {
-    "before": "ember-cli-sri",
     "after": "broccoli-asset-rev"
   },
   "release-it": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     }
   },
   "ember-addon": {
-    "after": "broccoli-asset-rev"
+    "before": "broccoli-asset-rev"
   },
   "release-it": {
     "plugins": {


### PR DESCRIPTION
Fixes #275.

ember-cli-terser 4.0.2 contains a regression documented in #275 which forces people using both ember-cli-terser and broccoli-asset-rev to pin ember-cli-terser to 4.0.1.

One way forward is to revert the change which introduced the regression (PR #266) and release this as 4.0.3.