### PR TITLE
Recursively assign Object properties to preserve sourcemap options

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { defaultsDeep } = require('ember-cli-lodash-subset');
+
 module.exports = {
   name: require('./package').name,
 
@@ -35,10 +37,10 @@ module.exports = {
     if ('ember-cli-uglify' in app.options) {
       this.ui.writeWarnLine('[ember-cli-terser] Passing options as `ember-cli-uglify` in `ember-cli-build.js` is deprecated, please update to passing `ember-cli-terser` (with a `terser` property) instead.');
 
-      addonOptions = Object.assign({}, app.options['ember-cli-uglify'], { terser: app.options['ember-cli-uglify'].uglify, uglify: undefined });
+      addonOptions = defaultsDeep({}, app.options['ember-cli-uglify'], { terser: app.options['ember-cli-uglify'].uglify, uglify: undefined })
     }
 
-    this._terserOptions = Object.assign({}, defaultOptions, addonOptions);
+    this._terserOptions = defaultsDeep({}, defaultOptions, addonOptions);
   },
 
   _sourceMapsEnabled(options) {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test": "ember test -e production"
   },
   "dependencies": {
-    "broccoli-terser-sourcemap": "^4.1.0"
+    "broccoli-terser-sourcemap": "^4.1.0",
+    "ember-cli-lodash-subset": "^2.0.1"
   },
   "devDependencies": {
     "ember-cli": "~3.22.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4067,6 +4067,7 @@ ember-cli-is-package-missing@^1.0.0:
 ember-cli-lodash-subset@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/ember-cli-lodash-subset/-/ember-cli-lodash-subset-2.0.1.tgz#20cb68a790fe0fde2488ddfd8efbb7df6fe766f2"
+  integrity sha512-QkLGcYv1WRK35g4MWu/uIeJ5Suk2eJXKtZ+8s+qE7C9INmpCPyPxzaqZABquYzcWNzIdw6kYwz3NWAFdKYFxwg==
 
 ember-cli-normalize-entity-name@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
```
Object.assign({
  terser: { sourceMap: false }
}, {
  terser: {}
})
```

results in `{ terser: { } }`. This results in the `souremap` option passed from `ember-cli-build.js` to get ignored and leads to sourceMaps being present in production builds as well.

Fixes #306 

I've skipped adding tests as there seems to be only a bare minimal test that runs a build and checks if tests are able to run.